### PR TITLE
fix: 퇴근일지에 저장된 이미지 가져오는 기능 수정

### DIFF
--- a/backend/src/entity/WorkDiaryImg.ts
+++ b/backend/src/entity/WorkDiaryImg.ts
@@ -22,8 +22,15 @@ export class WorkDiaryImg extends BaseEntity {
     workDiary: WorkDiary;
 
     static async findImgbyDiaryId(diaryId: number) {
+
+        const date = new Date();
+        let year: number = date.getFullYear();
+        let month: string = ("0" + (1 + date.getMonth())).slice(-2);
+        let day: string = ("0" + date.getDate()).slice(-2);
+
         return await this.createQueryBuilder("work_diary_img")
         .where("work_diary_img.workDiaryId = :diaryId", {diaryId: diaryId})
+        .andWhere("DATE_FORMAT(work_diary_img.createdAt, '%Y-%m-%d') = :date", {date: year + "-" + month + "-" + day})
         .getMany();
     }
 }


### PR DESCRIPTION
퇴근일지에 저장된 이미지 가져오는 기능 수정
- 기존에는 diary_id를 기준으로 가져옴 (단일 조건)
- 수정된 기능에서는 diary_id & 당일 날짜 (ex. 2022-04-14) 처럼 2개의 조건을 통해서 가져오도록 함